### PR TITLE
update code to correspond to latest scoringutils version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubEvals
 Title: Basic tools for scoring hubverse forecasts
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: c(
     person(given = "Nicholas", 
            family = "Reich",

--- a/R/transform_point_model_out.R
+++ b/R/transform_point_model_out.R
@@ -68,9 +68,8 @@ transform_point_model_out <- function(model_out_tbl, target_data, output_type) {
     relationship = "many-to-one"
   )
 
-  forecast_point <- scoringutils::as_forecast(data,
+  forecast_point <- scoringutils::as_forecast_point(data,
     forecast_unit = c("model", task_id_cols),
-    forecast_type = "point",
     observed = "observation",
     predicted = "value",
     model = "model"

--- a/R/transform_quantile_model_out.R
+++ b/R/transform_quantile_model_out.R
@@ -54,9 +54,8 @@ transform_quantile_model_out <- function(model_out_tbl, target_data) {
     relationship = "many-to-one"
   )
 
-  forecast_quantile <- scoringutils::as_forecast(data,
+  forecast_quantile <- scoringutils::as_forecast_quantile(data,
     forecast_unit = c("model", task_id_cols),
-    forecast_type = "quantile",
     observed = "observation",
     predicted = "value",
     model = "model",


### PR DESCRIPTION
Who would have thought that this would happen so soon :) 

`scoringutils` just got a new update which slightly changes the interface - `as_forecast` is now `as_forecast_quantile` and `as_forecast_point`. This PR updates the corresponding function to work with the most recent `scoringutils` version. 

Apologies for the short notice - in the future I'll try to coordinate PRs to make sure there is no gap between the two packages. 