### PR TITLE
Fix code after changes in scoringutils

### DIFF
--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -16,15 +16,17 @@
 #' @details If `metrics` is `NULL` (the default), this function chooses
 #' appropriate metrics based on the `output_type` contained in the `model_out_tbl`:
 #'
-#' - For `output_type == "quantile"`, we use the default metrics provided by
+#' \itemize{
+#' \item For `output_type == "quantile"`, we use the default metrics provided by
 #' `scoringutils`:
 #' `r names(scoringutils::get_metrics(scoringutils::example_quantile))`
-#' - For `output_type == "pmf"` and `output_type_id_order` is `NULL` (indicating
+#' \item For `output_type == "pmf"` and `output_type_id_order` is `NULL` (indicating
 #' that the predicted variable is a nominal variable), we use the default metric
-#' provided by `scoringutils`:,
+#' provided by `scoringutils`:
 #' `r names(scoringutils::get_metrics(scoringutils::example_nominal))`
-#'   - For `output_type == "median"`, we use "ae_point"
-#'   - For `output_type == "mean"`, we use "se_point"
+#'   \item For `output_type == "median"`, we use "ae_point"
+#'   \item For `output_type == "mean"`, we use "se_point"
+#' }
 #'
 #' Alternatively, a character vector of scoring metrics can be provided. In this
 #' case, the following options are supported:
@@ -46,7 +48,7 @@
 #'   - `output_type == "pmf"`:
 #'     - "log_score": log score
 #'
-#' See [scoringutils::get_metrics()] for more details on the default meterics
+#' See [scoringutils::get_metrics()] for more details on the default metrics
 #' used by `scoringutils`.
 #'
 #' @examplesIf requireNamespace("hubExamples", quietly = TRUE)

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -43,13 +43,16 @@ If \code{metrics} is \code{NULL} (the default), this function chooses
 appropriate metrics based on the \code{output_type} contained in the \code{model_out_tbl}:
 \itemize{
 \item For \code{output_type == "quantile"}, we use the default metrics provided by
-\code{scoringutils::metrics_quantile()}: wis, overprediction, underprediction, dispersion, bias, interval_coverage_50, interval_coverage_90, interval_coverage_deviation, ae_median
+\code{scoringutils}:
+\verb{r names(scoringutils::get_metrics(scoringutils::example_quantile))}
 \item For \code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL} (indicating
 that the predicted variable is a nominal variable), we use the default metric
-provided by \code{scoringutils::metrics_nominal()},
-log_score
+provided by \code{scoringutils}:,
+\verb{r names(scoringutils::get_metrics(scoringutils::example_nominal))}
+\itemize{
 \item For \code{output_type == "median"}, we use "ae_point"
 \item For \code{output_type == "mean"}, we use "se_point"
+}
 }
 
 Alternatively, a character vector of scoring metrics can be provided. In this
@@ -79,6 +82,9 @@ based on quantiles at the probability levels 0.025 and 0.975.
 \item "log_score": log score
 }
 }
+
+See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default meterics
+used by \code{scoringutils}.
 }
 \examples{
 \dontshow{if (requireNamespace("hubExamples", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -41,18 +41,17 @@ Score model output predictions with a single \code{output_type} against observed
 \details{
 If \code{metrics} is \code{NULL} (the default), this function chooses
 appropriate metrics based on the \code{output_type} contained in the \code{model_out_tbl}:
+
 \itemize{
 \item For \code{output_type == "quantile"}, we use the default metrics provided by
 \code{scoringutils}:
-\verb{r names(scoringutils::get_metrics(scoringutils::example_quantile))}
+wis, overprediction, underprediction, dispersion, bias, interval_coverage_50, interval_coverage_90, interval_coverage_deviation, ae_median
 \item For \code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL} (indicating
 that the predicted variable is a nominal variable), we use the default metric
-provided by \code{scoringutils}:,
-\verb{r names(scoringutils::get_metrics(scoringutils::example_nominal))}
-\itemize{
+provided by \code{scoringutils}:
+log_score
 \item For \code{output_type == "median"}, we use "ae_point"
 \item For \code{output_type == "mean"}, we use "se_point"
-}
 }
 
 Alternatively, a character vector of scoring metrics can be provided. In this
@@ -83,7 +82,7 @@ based on quantiles at the probability levels 0.025 and 0.975.
 }
 }
 
-See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default meterics
+See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default metrics
 used by \code{scoringutils}.
 }
 \examples{

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -441,7 +441,7 @@ test_that("score_model_out errors when invalid metrics are requested", {
     score_model_out(
       model_out_tbl = forecast_outputs |> dplyr::filter(.data[["output_type"]] == "mean"),
       target_observations = forecast_target_observations,
-      metrics = scoringutils::metrics_point(),
+      metrics = scoringutils::get_metrics(scoringutils::example_point),
       by = c("model_id", "location")
     ),
     regexp = "`metrics` must be either `NULL` or a character vector of supported metrics."
@@ -464,3 +464,4 @@ test_that("score_model_out errors when an unsupported output_type is provided", 
     regexp = "only supports the following types"
   )
 })
+

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -464,4 +464,3 @@ test_that("score_model_out errors when an unsupported output_type is provided", 
     regexp = "only supports the following types"
   )
 })
-

--- a/tests/testthat/test-transform_point_model_out.R
+++ b/tests/testthat/test-transform_point_model_out.R
@@ -146,5 +146,3 @@ test_that("hubExamples data set is transformed correctly", {
   )
   expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })
-
-

--- a/tests/testthat/test-transform_point_model_out.R
+++ b/tests/testthat/test-transform_point_model_out.R
@@ -140,6 +140,11 @@ test_that("hubExamples data set is transformed correctly", {
       reference_date = as.Date(reference_date, "%Y-%m-%d"),
       target_end_date = as.Date(target_end_date, "%Y-%m-%d")
     )
-  class(exp_forecast) <- c("forecast_point", "forecast", "data.table", "data.frame")
-  expect_equal(act_forecast, exp_forecast)
+  expect_s3_class(
+    act_forecast,
+    c("forecast_point", "forecast", "data.table", "data.frame")
+  )
+  expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })
+
+

--- a/tests/testthat/test-transform_quantile_model_out.R
+++ b/tests/testthat/test-transform_quantile_model_out.R
@@ -89,6 +89,9 @@ test_that("hubExamples data set is transformed correctly", {
       reference_date = as.Date(reference_date, "%Y-%m-%d"),
       target_end_date = as.Date(target_end_date, "%Y-%m-%d")
     )
-  class(exp_forecast) <- c("forecast", "forecast_quantile", "data.table", "data.frame")
-  expect_equal(act_forecast, exp_forecast, ignore_attr = "class")
+  expect_s3_class(
+    act_forecast,
+    c("forecast_quantile", "forecast", "data.table", "data.frame")
+  )
+  expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })


### PR DESCRIPTION
In https://github.com/epiforecasts/scoringutils/pull/903 we changed the scoringutils behaviour surrounding the default metrics. This PR fixes the current code to conform with the new update. 

I'll make additional suggestions in separate PRs. 

I also fixed a failing test where scoringutils produced a warning in `expect_equal`. Sorry for that! Converting the data to data.frames avoids issues with scoringutils internally validating things it shouldn't be validating. 