### PR TITLE
Update to latest roxygen and fix package imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Description:
 License: MIT + file LICENSE
 Encoding: UTF-8
 Imports:
-    checkmate, 
     cli,
     dplyr,
     hubUtils,
@@ -51,7 +50,7 @@ Remotes:
     hubverse-org/hubExamples,
     hubverse-org/hubUtils
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://hubverse-org.github.io/hubEvals/
 Depends: 
     R (>= 2.10)


### PR DESCRIPTION
`checkmate` isn't used anywhere in the package, so it should not appear in Imports. I also updated Roxygen to the newest version. 