### PR TITLE
Score model out improvements

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^\.Rdata$
 ^\.httr-oauth$
 ^\.secrets$
+^.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs
 .Rdata
 .secrets
 .quarto
+
+.vscode/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Remotes:
     hubverse-org/hubExamples,
     hubverse-org/hubUtils
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://hubverse-org.github.io/hubEvals/
 Depends: 
     R (>= 2.10)

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -81,7 +81,7 @@
 #' @return A data.table with scores
 #'
 #' @references
-#' Gneiting, Tilmann. 2011. "Making and Evaluating Point Forecasts." Journal of the 
+#' Gneiting, Tilmann. 2011. "Making and Evaluating Point Forecasts." Journal of the
 #' American Statistical Association 106 (494): 746–62. <doi: 10.1198/jasa.2011.r10138>.
 #'
 #' @export

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -16,15 +16,17 @@
 #' @details If `metrics` is `NULL` (the default), this function chooses
 #' appropriate metrics based on the `output_type` contained in the `model_out_tbl`:
 #'
-#' - For `output_type == "quantile"`, we use the default metrics provided by
+#' \itemize{
+#' \item For `output_type == "quantile"`, we use the default metrics provided by
 #' `scoringutils`:
 #' `r names(scoringutils::get_metrics(scoringutils::example_quantile))`
-#' - For `output_type == "pmf"` and `output_type_id_order` is `NULL` (indicating
+#' \item For `output_type == "pmf"` and `output_type_id_order` is `NULL` (indicating
 #' that the predicted variable is a nominal variable), we use the default metric
-#' provided by `scoringutils`:,
+#' provided by `scoringutils`:
 #' `r names(scoringutils::get_metrics(scoringutils::example_nominal))`
-#'   - For `output_type == "median"`, we use "ae_point"
-#'   - For `output_type == "mean"`, we use "se_point"
+#'   \item For `output_type == "median"`, we use "ae_point"
+#'   \item For `output_type == "mean"`, we use "se_point"
+#' }
 #'
 #' Alternatively, a character vector of scoring metrics can be provided. In this
 #' case, the following options are supported:
@@ -46,7 +48,7 @@
 #'   - `output_type == "pmf"`:
 #'     - "log_score": log score
 #'
-#' See [scoringutils::get_metrics()] for more details on the default meterics
+#' See [scoringutils::get_metrics()] for more details on the default metrics
 #' used by `scoringutils`.
 #'
 #' @examplesIf requireNamespace("hubExamples", quietly = TRUE)

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -81,8 +81,8 @@
 #' @return A data.table with scores
 #'
 #' @references
-#' Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
-#' Journal of the American Statistical Association.
+#' Gneiting, Tilmann. 2011. "Making and Evaluating Point Forecasts." Journal of the 
+#' American Statistical Association 106 (494): 746–62. <doi: 10.1198/jasa.2011.r10138>.
 #'
 #' @export
 score_model_out <- function(model_out_tbl, target_observations, metrics = NULL,

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -81,7 +81,7 @@
 #' @return A data.table with scores
 #'
 #' @references
-#' #' Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
+#' Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
 #' Journal of the American Statistical Association.
 #'
 #' @export

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -148,9 +148,9 @@ get_metrics <- function(forecast, output_type, select = NULL) {
         level_str <- substr(metric, 19, nchar(metric))
         level <- suppressWarnings(as.numeric(level_str))
         if (is.na(level) || level <= 0 || level >= 100) {
-          stop(paste(
-            "Invalid interval coverage level:", level_str,
-            "- must be a number between 0 and 100 (exclusive)"
+          cli::cli_abort(c(
+            "Invalid interval coverage level: {level_str}",
+            "i" = "must be a number between 0 and 100 (exclusive)"
           ))
         }
         return(purrr::partial(scoringutils::interval_coverage, interval_range = level))

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -135,7 +135,7 @@ get_metrics <- function(forecast, output_type, select = NULL) {
   # coverage metrics
   if (forecast_type == "forecast_quantile") {
     # split into metrics for interval coverage and others
-    interval_metric_inds <- grepl(pattern = "interval_coverage_", select)
+    interval_metric_inds <- grepl(pattern = "^interval_coverage_", select)
     interval_metrics <- select[interval_metric_inds]
     other_metrics <- select[!interval_metric_inds]
 

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/score_model_out.R
 \name{score_model_out}
 \alias{score_model_out}
-\title{Score model output predictions with a single \code{output_type} against observed data}
+\title{Score model output predictions}
 \usage{
 score_model_out(
   model_out_tbl,
@@ -19,7 +19,9 @@ score_model_out(
 \item{target_observations}{Observed 'ground truth' data to be compared to
 predictions}
 
-\item{metrics}{Optional character vector of scoring metrics to compute. See details for more.}
+\item{metrics}{Character vector of scoring metrics to compute. If \code{NULL}
+(the default), appropriate metrics are chosen automatically. See details
+for more.}
 
 \item{summarize}{Boolean indicator of whether summaries of forecast scores
 should be computed. Defaults to \code{TRUE}.}
@@ -33,57 +35,55 @@ vector of levels for pmf forecasts, in increasing order of the levels. For
 all other output types, this is ignored.}
 }
 \value{
-forecast_quantile
+A data.table with scores
 }
 \description{
-Score model output predictions with a single \code{output_type} against observed data
+Scores model outputs with a single \code{output_type} against observed data.
 }
 \details{
-If \code{metrics} is \code{NULL} (the default), this function chooses
-appropriate metrics based on the \code{output_type} contained in the \code{model_out_tbl}:
+Default metrics are provided by the \code{scoringutils} package. You can select
+metrics by passing in a character vector of metric names to the \code{metrics}
+argument.
 
-\itemize{
-\item For \code{output_type == "quantile"}, we use the default metrics provided by
-\code{scoringutils}:
-wis, overprediction, underprediction, dispersion, bias, interval_coverage_50, interval_coverage_90, interval_coverage_deviation, ae_median
-\item For \code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL} (indicating
-that the predicted variable is a nominal variable), we use the default metric
-provided by \code{scoringutils}:
-log_score
-\item For \code{output_type == "median"}, we use "ae_point"
-\item For \code{output_type == "mean"}, we use "se_point"
-}
+The following metrics can be selected (all are used by default) for the
+different \code{output_type}s:
 
-Alternatively, a character vector of scoring metrics can be provided. In this
-case, the following options are supported:
+\strong{Quantile forecasts:} (\code{output_type == "quantile"})
 \itemize{
-\item \code{output_type == "median"} and \code{output_type == "mean"}:
-\itemize{
-\item "ae_point": absolute error of a point prediction (generally recommended for the median)
-\item "se_point": squared error of a point prediction (generally recommended for the mean)
-}
-\item \code{output_type == "quantile"}:
-\itemize{
-\item "ae_median": absolute error of the predictive median (i.e., the quantile at probability level 0.5)
-\item "wis": weighted interval score (WIS) of a collection of quantile predictions
-\item "overprediction": The component of WIS measuring the extent to which
-predictions fell above the observation.
-\item "underprediction": The component of WIS measuring the extent to which
-predictions fell below the observation.
-\item "dispersion":  The component of WIS measuring the dispersion of forecast
-distributions.
+\item wis
+\item overprediction
+\item underprediction
+\item dispersion
+\item bias
+\item interval_coverage_deviation
+\item ae_median
 \item "interval_coverage_XX": interval coverage at the "XX" level. For example,
 "interval_coverage_95" is the 95\% interval coverage rate, which would be calculated
 based on quantiles at the probability levels 0.025 and 0.975.
 }
-\item \code{output_type == "pmf"}:
+
+See \link[scoringutils:get_metrics.forecast_quantile]{scoringutils::get_metrics.forecast_quantile} for details.
+
+\strong{Nominal forecasts:} (\code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL})
 \itemize{
-\item "log_score": log score
-}
+\item log_score
 }
 
-See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default metrics
-used by \code{scoringutils}.
+(scoring for ordinal forecasts will be added in the future).
+
+See \link[scoringutils:get_metrics.forecast_nominal]{scoringutils::get_metrics.forecast_nominal} for details.
+
+\strong{Median forecasts:} (\code{output_type == "median"})
+\itemize{
+\item ae_point: absolute error of the point forecast (recommended for the median, see Gneiting (2011))
+}
+
+See \link[scoringutils:get_metrics.forecast_point]{scoringutils::get_metrics.forecast_point} for details.
+
+\strong{Mean forecasts:} (\code{output_type == "mean"})
+\itemize{
+\item \code{se_point}: squared error of the point forecast (recommended for the mean, see Gneiting (2011))
+}
 }
 \examples{
 \dontshow{if (requireNamespace("hubExamples", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -112,4 +112,8 @@ pmf_scores <- score_model_out(
 )
 head(pmf_scores)
 \dontshow{\}) # examplesIf}
+}
+\references{
+#' Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
+Journal of the American Statistical Association.
 }

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -43,13 +43,16 @@ If \code{metrics} is \code{NULL} (the default), this function chooses
 appropriate metrics based on the \code{output_type} contained in the \code{model_out_tbl}:
 \itemize{
 \item For \code{output_type == "quantile"}, we use the default metrics provided by
-\code{scoringutils::metrics_quantile()}: wis, overprediction, underprediction, dispersion, bias, interval_coverage_50, interval_coverage_90, interval_coverage_deviation, ae_median
+\code{scoringutils}:
+\verb{r names(scoringutils::get_metrics(scoringutils::example_quantile))}
 \item For \code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL} (indicating
 that the predicted variable is a nominal variable), we use the default metric
-provided by \code{scoringutils::metrics_nominal()},
-log_score
+provided by \code{scoringutils}:,
+\verb{r names(scoringutils::get_metrics(scoringutils::example_nominal))}
+\itemize{
 \item For \code{output_type == "median"}, we use "ae_point"
 \item For \code{output_type == "mean"}, we use "se_point"
+}
 }
 
 Alternatively, a character vector of scoring metrics can be provided. In this
@@ -79,6 +82,9 @@ based on quantiles at the probability levels 0.025 and 0.975.
 \item "log_score": log score
 }
 }
+
+See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default meterics
+used by \code{scoringutils}.
 }
 \examples{
 \dontshow{if (requireNamespace("hubExamples", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -41,18 +41,17 @@ Score model output predictions with a single \code{output_type} against observed
 \details{
 If \code{metrics} is \code{NULL} (the default), this function chooses
 appropriate metrics based on the \code{output_type} contained in the \code{model_out_tbl}:
+
 \itemize{
 \item For \code{output_type == "quantile"}, we use the default metrics provided by
 \code{scoringutils}:
-\verb{r names(scoringutils::get_metrics(scoringutils::example_quantile))}
+wis, overprediction, underprediction, dispersion, bias, interval_coverage_50, interval_coverage_90, interval_coverage_deviation, ae_median
 \item For \code{output_type == "pmf"} and \code{output_type_id_order} is \code{NULL} (indicating
 that the predicted variable is a nominal variable), we use the default metric
-provided by \code{scoringutils}:,
-\verb{r names(scoringutils::get_metrics(scoringutils::example_nominal))}
-\itemize{
+provided by \code{scoringutils}:
+log_score
 \item For \code{output_type == "median"}, we use "ae_point"
 \item For \code{output_type == "mean"}, we use "se_point"
-}
 }
 
 Alternatively, a character vector of scoring metrics can be provided. In this
@@ -83,7 +82,7 @@ based on quantiles at the probability levels 0.025 and 0.975.
 }
 }
 
-See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default meterics
+See \code{\link[scoringutils:get_metrics]{scoringutils::get_metrics()}} for more details on the default metrics
 used by \code{scoringutils}.
 }
 \examples{

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -114,6 +114,6 @@ head(pmf_scores)
 \dontshow{\}) # examplesIf}
 }
 \references{
-#' Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
+Making and Evaluating Point Forecasts, Gneiting, Tilmann, 2011,
 Journal of the American Statistical Association.
 }

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -448,6 +448,16 @@ test_that("score_model_out errors when invalid metrics are requested", {
 
   expect_error(
     score_model_out(
+      model_out_tbl = forecast_outputs |> dplyr::filter(.data[["output_type"]] == "quantile"),
+      target_observations = forecast_target_observations,
+      metrics = c("asdfinterval_coverage_90")
+    ),
+    regexp =
+      "has additional elements"
+  )
+
+  expect_error(
+    score_model_out(
       model_out_tbl = forecast_outputs |> dplyr::filter(.data[["output_type"]] == "mean"),
       target_observations = forecast_target_observations,
       metrics = scoringutils::get_metrics(scoringutils::example_point),

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -441,7 +441,7 @@ test_that("score_model_out errors when invalid metrics are requested", {
     score_model_out(
       model_out_tbl = forecast_outputs |> dplyr::filter(.data[["output_type"]] == "mean"),
       target_observations = forecast_target_observations,
-      metrics = scoringutils::metrics_point(),
+      metrics = scoringutils::get_metrics(scoringutils::example_point),
       by = c("model_id", "location")
     ),
     regexp = "`metrics` must be either `NULL` or a character vector of supported metrics."
@@ -464,3 +464,4 @@ test_that("score_model_out errors when an unsupported output_type is provided", 
     regexp = "only supports the following types"
   )
 })
+

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -464,4 +464,3 @@ test_that("score_model_out errors when an unsupported output_type is provided", 
     regexp = "only supports the following types"
   )
 })
-

--- a/tests/testthat/test-transform_point_model_out.R
+++ b/tests/testthat/test-transform_point_model_out.R
@@ -146,5 +146,3 @@ test_that("hubExamples data set is transformed correctly", {
   )
   expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })
-
-

--- a/tests/testthat/test-transform_point_model_out.R
+++ b/tests/testthat/test-transform_point_model_out.R
@@ -140,6 +140,11 @@ test_that("hubExamples data set is transformed correctly", {
       reference_date = as.Date(reference_date, "%Y-%m-%d"),
       target_end_date = as.Date(target_end_date, "%Y-%m-%d")
     )
-  class(exp_forecast) <- c("forecast_point", "forecast", "data.table", "data.frame")
-  expect_equal(act_forecast, exp_forecast)
+  expect_s3_class(
+    act_forecast,
+    c("forecast_point", "forecast", "data.table", "data.frame")
+  )
+  expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })
+
+

--- a/tests/testthat/test-transform_quantile_model_out.R
+++ b/tests/testthat/test-transform_quantile_model_out.R
@@ -89,6 +89,9 @@ test_that("hubExamples data set is transformed correctly", {
       reference_date = as.Date(reference_date, "%Y-%m-%d"),
       target_end_date = as.Date(target_end_date, "%Y-%m-%d")
     )
-  class(exp_forecast) <- c("forecast", "forecast_quantile", "data.table", "data.frame")
-  expect_equal(act_forecast, exp_forecast, ignore_attr = "class")
+  expect_s3_class(
+    act_forecast,
+    c("forecast_quantile", "forecast", "data.table", "data.frame")
+  )
+  expect_equal(as.data.frame(act_forecast), as.data.frame(exp_forecast))
 })


### PR DESCRIPTION
(builds on #52)

This PR simplifies `score_model_out`, mostly by offloading a bunch of the heavy work to `scoringutils`. In particular it
- simplifies the documentation to mostly rely on the function explanations in scoringutils. Mostly a matter of taste - my impression is it make easier to maintain the docs in the future
- moves most of the logic for obtaining default metrics from `hubEvals` to `scoringutils`.
- amends the `interval_coverage_XY` a bit to allow for all numbers in (0, 100). 
- restricts the metrics for `mean` and `median` forecasts to the ones suggested by Gneiting. Personally I think it makes sense to simply not return something we know is flawed.

Moving the logic to `scoringutils` makes the code easier and more concise. Errors are handled by `scoringutils` which comes with both upsides and downsides. The upside is it's all cleanly handled and we don't need to worry about it. 

The major downside is that error messages are slightly less "nice". E.g. when you pass something like `metrics = list("a", "b")` to `score_model_out`, then you'll get an error message `Assertion on 'c(select, exclude)' failed: Must be of type 'character' (or 'NULL'), not 'list'.` If we don't like the current error messages I suggest we catch the errors and replace them with new messages. But I think it's still cleaner to have the logic be handled by `scoringutils` instead of re-implementing it here.