### PR TITLE
Release hubEvals 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubEvals
 Title: Basic tools for scoring hubverse forecasts
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: c(
     person(given = "Nicholas", 
            family = "Reich",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubEvals (development version)
+# hubEvals 0.2.0
 
 * Add support for scoring sample output types via `transform_sample_model_out()` and the `"sample"` case in `score_model_out()`. Marginal scoring produces metrics such as CRPS, bias, and DSS; compound scoring (via the new `compound_taskid_set` argument) produces multivariate scores such as energy score and variogram score for joint forecasts (#94).
 


### PR DESCRIPTION
## Summary

- Add support for scoring sample output types via `transform_sample_model_out()` and the `"sample"` case in `score_model_out()`. Marginal scoring produces metrics such as CRPS, bias, and DSS; compound scoring (via the new `compound_taskid_set` argument) produces multivariate scores such as energy score and variogram score for joint forecasts (#94).
- `score_model_out()` now errors with a clear message when a scale transformation produces non-finite values (NaN or Inf), instead of silently returning invalid scores (#99).