### PR TITLE
Add hubExamples to website deps so that function examples render in website API reference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,9 @@ BugReports: https://github.com/hubverse-org/hubEvals/issues
 Additional_repositories: https://hubverse-org.r-universe.dev
 Depends:
     R (>= 4.1.0)
-Config/Needs/website: hubverse-org/hubStyle
+Config/Needs/website: 
+    hubExamples,
+    hubverse-org/hubStyle
 Suggests:
     hubExamples,
     testthat (>= 3.0.0)


### PR DESCRIPTION
Many key functions (e.g. [`transform_sample_model_out`](https://hubverse-org.github.io/hubEvals/reference/transform_sample_model_out.html)) have examples that render only if `hubExamples` is available. By adding it to `Config/Needs/website`, we can ensure the examples render in the public docs.