### PR TITLE
Preserve scale in summary when transform_append = TRUE (#122)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubEvals (development version)
 
+* Fix `score_model_out()` so that requesting `transform_append = TRUE` with default `summarize = TRUE` now correctly returns one row per `scale` (natural and transformed) per model, instead of silently averaging across scales (#122).
+
 * `score_model_out()` now returns a tibble (inheriting from scoringutils' `scores` class) instead of a `data.table`. This gives more predictable user-facing behaviour (e.g. with `$` access, printing, and dplyr) while keeping the `scores` class so downstream scoringutils helpers like `get_metrics()` continue to work (#70).
 
 * `score_model_out()` now errors when no requested metric produces a score.

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -305,7 +305,14 @@ score_model_out <- function(
       )
     }
     # END workaround mirror for scoringutils#1180
-    scores <- scoringutils::summarize_scores(scores = scores, by = by)
+
+    # When transform_append = TRUE, scoringutils emits both natural- and
+    # transformed-scale rows distinguished by a `scale` column. Include
+    # "scale" in `by` for the summary so the two scales are reported
+    # separately rather than collapsed into a meaningless average. The
+    # user-facing `by` argument is not modified outside this block.
+    summary_by <- if (isTRUE(transform_append)) union(by, "scale") else by
+    scores <- scoringutils::summarize_scores(scores = scores, by = summary_by)
   }
 
   # Convert to tibble for friendlier user-facing behaviour, but keep the

--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -733,6 +733,43 @@ test_that("score_model_out with transform_append=TRUE includes both scales", {
 })
 
 
+test_that("score_model_out with transform_append=TRUE preserves scale when summarising (#122)", {
+  skip_if_not_installed("hubExamples")
+  forecast_outputs <- hubExamples::forecast_outputs
+  forecast_oracle_output <- hubExamples::forecast_oracle_output
+  quantile_out <- forecast_outputs |>
+    dplyr::filter(.data[["output_type"]] == "quantile")
+
+  # Default summarize = TRUE + default by = "model_id" should keep the two
+  # scales distinct (regression test: previously the natural and
+  # transformed-scale rows were collapsed into a single average per model).
+  scores <- score_model_out(
+    model_out_tbl = quantile_out,
+    oracle_output = forecast_oracle_output,
+    metrics = "wis",
+    transform = scoringutils::log_shift,
+    transform_append = TRUE,
+    offset = 1
+  )
+
+  expect_true("scale" %in% colnames(scores))
+  expect_setequal(unique(scores$scale), c("natural", "log_shift"))
+  expect_equal(nrow(scores), 2 * dplyr::n_distinct(scores$model_id))
+
+  # Cross-check: default by must match explicit `by = c("model_id", "scale")`.
+  scores_explicit <- score_model_out(
+    model_out_tbl = quantile_out,
+    oracle_output = forecast_oracle_output,
+    metrics = "wis",
+    transform = scoringutils::log_shift,
+    transform_append = TRUE,
+    offset = 1,
+    by = c("model_id", "scale")
+  )
+  expect_equal(scores, scores_explicit)
+})
+
+
 test_that("score_model_out errors when transform requested for pmf output_type", {
   skip_if_not_installed("hubExamples")
   forecast_outputs <- hubExamples::forecast_outputs


### PR DESCRIPTION
Closes #122.

## Problem

When `score_model_out()` is called with `transform_append = TRUE` and the default `summarize = TRUE`, the internal summarisation step previously collapsed the natural and transformed-scale rows together because `"scale"` was not in the default `by = "model_id"`. The result was a single row per model whose WIS / CRPS / etc. values were a meaningless arithmetic average across the two scales.

Users requesting `transform_append = TRUE` do so specifically to compare scales side by side, so the default behaviour was the opposite of what they want.

## Fix

One-line change in `R/score_model_out.R`: include `"scale"` in `by` for the summary step whenever `transform_append = TRUE`. The user-facing `by` argument is not modified outside this block.

```r
summary_by <- if (isTRUE(transform_append)) union(by, "scale") else by
scores <- scoringutils::summarize_scores(scores = scores, by = summary_by)
```

Default-by callers now get one row per `(model_id, scale)` combination, matching what they would have got by passing `by = c("model_id", "scale")` explicitly (and matching the documented intent of `transform_append`).

## Test gap addressed

All existing `transform_append = TRUE` tests set `summarize = FALSE`, which sidestepped the summarisation path entirely. Adds a regression test covering the default-summary path that:

- asserts a `scale` column is present in the summarised output
- asserts both `natural` and the transformed label appear
- asserts the row count is `2 * n_models`
- cross-checks values against an explicit `by = c("model_id", "scale")` call

## Test plan

- [x] `devtools::test()` passes (170 / 170, up from 166)
- [x] `devtools::check(args = c("--no-manual"))` clean (0 errors, 0 warnings, only the harmless future-timestamp NOTE)
- [x] `air format . --check` clean
- [x] `lintr::lint_package()` clean

## Follow-up

The getting-started vignette (PR #121) is currently working around this by passing `by = c("model_id", "scale")` explicitly in two demos and explaining why in prose. Once this merges, that PR will be rebased and the workaround removed so the vignette can teach the natural default-arg pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)