### PR TITLE
Hard-gate bias from relative metrics (#119)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix `score_model_out()` so that requesting `transform_append = TRUE` with default `summarize = TRUE` now correctly returns one row per `scale` (natural and transformed) per model, instead of silently averaging across scales (#122).
 
+* `score_model_out()` now errors with a clear hubEvals message when `"bias"` is requested as a relative metric, instead of letting `scoringutils` fail downstream with a cryptic "all values must have the same sign" error. Bias is a signed quantity, so a geometric-mean pairwise ratio has no clean interpretation (#119).
+
 * `score_model_out()` now returns a tibble (inheriting from scoringutils' `scores` class) instead of a `data.table`. This gives more predictable user-facing behaviour (e.g. with `$` access, printing, and dplyr) while keeping the `scores` class so downstream scoringutils helpers like `get_metrics()` continue to work (#70).
 
 * `score_model_out()` now errors when no requested metric produces a score.

--- a/R/score_model_out.R
+++ b/R/score_model_out.R
@@ -10,10 +10,13 @@
 #' for more.
 #' @param relative_metrics Character vector of scoring metrics for which to
 #' compute relative skill scores. The `relative_metrics` should be a subset of
-#' `metrics` and should only include proper scores (e.g., it should not contain
-#' interval coverage metrics).  If `NULL` (the default), no relative metrics
-#' will be computed.  Relative metrics are only computed if `summarize = TRUE`,
-#' and require that `"model_id"` is included in `by`.
+#' `metrics` and should only include proper scores. Interval coverage metrics
+#' (e.g., `"interval_coverage_90"`) and `"bias"` are not supported as relative
+#' metrics: interval coverage targets a nominal level rather than a "lower is
+#' better" direction, and bias is a signed quantity for which a geometric-mean
+#' pairwise ratio has no clean interpretation. If `NULL` (the default), no
+#' relative metrics will be computed. Relative metrics are only computed if
+#' `summarize = TRUE`, and require that `"model_id"` is included in `by`.
 #' @param baseline String with the name of a model to use as a baseline for
 #' relative skill scores. If a baseline is given, then a scaled relative skill
 #' with respect to the baseline will be returned. By default (`NULL`), relative

--- a/R/validate.R
+++ b/R/validate.R
@@ -121,6 +121,16 @@ validate_relative_metrics <- function(relative_metrics, metrics, by) {
     )
   }
 
+  if ("bias" %in% relative_metrics) {
+    cli::cli_abort(
+      c(
+        "{.val bias} is not supported for relative skill scores.",
+        "i" = "Bias is a signed quantity, so a geometric-mean pairwise ratio has no clean interpretation.",
+        "i" = "Drop {.val bias} from {.arg relative_metrics} (it can still be requested via {.arg metrics})."
+      )
+    )
+  }
+
   if (length(relative_metrics) > 0 && !"model_id" %in% by) {
     cli::cli_abort(
       "Relative metrics require 'model_id' to be included in {.arg by}."

--- a/man/score_model_out.Rd
+++ b/man/score_model_out.Rd
@@ -32,10 +32,13 @@ for more.}
 
 \item{relative_metrics}{Character vector of scoring metrics for which to
 compute relative skill scores. The \code{relative_metrics} should be a subset of
-\code{metrics} and should only include proper scores (e.g., it should not contain
-interval coverage metrics).  If \code{NULL} (the default), no relative metrics
-will be computed.  Relative metrics are only computed if \code{summarize = TRUE},
-and require that \code{"model_id"} is included in \code{by}.}
+\code{metrics} and should only include proper scores. Interval coverage metrics
+(e.g., \code{"interval_coverage_90"}) and \code{"bias"} are not supported as relative
+metrics: interval coverage targets a nominal level rather than a "lower is
+better" direction, and bias is a signed quantity for which a geometric-mean
+pairwise ratio has no clean interpretation. If \code{NULL} (the default), no
+relative metrics will be computed. Relative metrics are only computed if
+\code{summarize = TRUE}, and require that \code{"model_id"} is included in \code{by}.}
 
 \item{baseline}{String with the name of a model to use as a baseline for
 relative skill scores. If a baseline is given, then a scaled relative skill

--- a/tests/testthat/test-score_model_out_rel_metrics.R
+++ b/tests/testthat/test-score_model_out_rel_metrics.R
@@ -74,6 +74,20 @@ test_that("score_model_out errors when invalid relative metrics are requested", 
     regexp = "Interval coverage metrics are not supported for relative skill scores."
   )
 
+  # not allowed to compute relative skill for bias: hubEvals errors at the
+  # boundary, before scoringutils fails with its "same sign" message.
+  quantile_out <- forecast_outputs |>
+    dplyr::filter(.data[["output_type"]] == "quantile")
+  expect_error(
+    score_model_out(
+      model_out_tbl = quantile_out,
+      oracle_output = forecast_oracle_output,
+      metrics = c("wis", "bias"),
+      relative_metrics = "bias"
+    ),
+    regexp = "bias.*not supported for relative skill scores"
+  )
+
   # relative_metrics must be a subset of metrics
   expect_error(
     score_model_out(

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -27,3 +27,25 @@ test_that("get_transform_label errors for anonymous function without label", {
     regexp = "transform_label.*required.*anonymous transform function"
   )
 })
+
+
+test_that("validate_relative_metrics rejects bias as a relative metric", {
+  expect_error(
+    validate_relative_metrics(
+      relative_metrics = "bias",
+      metrics = c("wis", "bias"),
+      by = "model_id"
+    ),
+    regexp = "bias.*not supported for relative skill scores"
+  )
+
+  # Mixed with a valid relative metric: still errors
+  expect_error(
+    validate_relative_metrics(
+      relative_metrics = c("wis", "bias"),
+      metrics = c("wis", "bias"),
+      by = "model_id"
+    ),
+    regexp = "bias.*not supported for relative skill scores"
+  )
+})


### PR DESCRIPTION
Closes #119.

## Summary

- Reject `"bias"` in `relative_metrics` at the hubEvals boundary in `validate_relative_metrics()`, mirroring the existing interval-coverage gate. Previously the request fell through to `scoringutils` and failed with a cryptic "all values of `bias` must have the same sign" error, which nudges users toward the wrong fix (force same sign) rather than the right one (don't use bias as a relative metric).
- Update the `relative_metrics` roxygen on `score_model_out()` to call out both blocked cases (interval coverage and bias) and why.
- Add unit test in `test-validate.R` (direct `validate_relative_metrics()` call) and end-to-end test in `test-score_model_out_rel_metrics.R` alongside the existing interval-coverage gate test.

## Test plan

- [x] `devtools::test()` — 169 passing, 0 failing
- [x] `air format . --check` clean
- [x] `lintr::lint_package()` clean
- [x] New tests assert the hubEvals message fires, not the scoringutils same-sign one

🤖 Generated with [Claude Code](https://claude.com/claude-code)