### PR TITLE
Drop sample-value clamp now that hubExamples is fixed (#100)

### DIFF
--- a/tests/testthat/test-score_model_out.R
+++ b/tests/testthat/test-score_model_out.R
@@ -1059,9 +1059,6 @@ test_that("score_model_out succeeds with marginal sample and scale transformatio
 
   sample_tbl <- forecast_outputs |>
     dplyr::filter(.data[["output_type"]] == "sample")
-  # Workaround for stale negative value in hubExamples data
-  # (hubverse-org/hubExamples#62). Remove once fixed.
-  sample_tbl$value[sample_tbl$value < 0] <- 0
 
   scores <- score_model_out(
     model_out_tbl = sample_tbl,
@@ -1085,7 +1082,6 @@ test_that("score_model_out with sample transform_append=TRUE includes both scale
 
   sample_tbl <- forecast_outputs |>
     dplyr::filter(.data[["output_type"]] == "sample")
-  sample_tbl$value[sample_tbl$value < 0] <- 0
 
   scores <- score_model_out(
     model_out_tbl = sample_tbl,
@@ -1124,7 +1120,6 @@ test_that("score_model_out succeeds with compound sample and scale transformatio
 
   sample_tbl <- forecast_outputs |>
     dplyr::filter(.data[["output_type"]] == "sample")
-  sample_tbl$value[sample_tbl$value < 0] <- 0
 
   scores <- score_model_out(
     model_out_tbl = sample_tbl,
@@ -1149,7 +1144,6 @@ test_that("score_model_out with compound sample transform_append=TRUE includes b
 
   sample_tbl <- forecast_outputs |>
     dplyr::filter(.data[["output_type"]] == "sample")
-  sample_tbl$value[sample_tbl$value < 0] <- 0
 
   scores <- score_model_out(
     model_out_tbl = sample_tbl,


### PR DESCRIPTION
Closes #100.

## Summary

The four sample-transform tests in `test-score_model_out.R` clamped a stale negative value (`-2`) to zero as a workaround for hubverse-org/hubExamples#62. That upstream issue is now closed, and `hubExamples::forecast_outputs` no longer contains negative sample values, so the workaround can go.

Verified locally:

```r
sample_rows <- hubExamples::forecast_outputs |> dplyr::filter(output_type == "sample")
min(sample_rows$value)
#> [1] 0
sum(sample_rows$value < 0)
#> [1] 0
```

## Test plan

- [x] `devtools::test()` — all tests pass (the four affected tests now exercise the real, non-clamped data)
- [x] `air format . --check` clean
- [x] `lintr::lint_package()` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)