### PR TITLE
Add GitHub repo URL to DESCRIPTION so pkgdown shows the GitHub icon (#36)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Imports:
     tibble
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-URL: https://hubverse-org.github.io/hubEvals/
+URL: https://hubverse-org.github.io/hubEvals/, https://github.com/hubverse-org/hubEvals
 BugReports: https://github.com/hubverse-org/hubEvals/issues
 Additional_repositories: https://hubverse-org.r-universe.dev
 Depends:


### PR DESCRIPTION
Closes #36.

## Summary

pkgdown auto-derives the GitHub navbar icon from a `github.com/...` entry in DESCRIPTION's URL field. hubEvals' DESCRIPTION only listed the pkgdown site URL, which is why the navbar was missing the icon that other hubverse sites (e.g. hubCI) display.

```diff
-URL: https://hubverse-org.github.io/hubEvals/
+URL: https://hubverse-org.github.io/hubEvals/, https://github.com/hubverse-org/hubEvals
```

## Test plan

- [x] `pkgdown::as_pkgdown(".")$repo$url$home` now resolves to `https://github.com/hubverse-org/hubEvals/`
- [x] `pkgdown:::data_navbar(...)$right` now includes the `<a aria-label="GitHub">` element
- [x] Confirm the icon appears on the rendered Netlify PR preview (auto-deployed by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)